### PR TITLE
Fix homepage grid spacing - Prevent box collisions and overflow

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -160,11 +160,11 @@ section {
 .parent {
     display: grid;
     grid-template-columns: repeat(5, 5fr);
-    grid-template-rows: repeat(2, 0.1fr) repeat(2, 0.1fr) 0fr;
-    grid-column-gap: 2.5%;
-    padding-bottom: 3%;
-    padding-top: 1%;
-    grid-row-gap: 2%;
+    grid-template-rows: repeat(2, 0.5fr) repeat(2, 0.5fr) 0fr;
+    grid-column-gap: 3%;
+    padding-bottom: 5%;
+    padding-top: 3%;
+    grid-row-gap: 5%;
     grid-auto-flow: column;
 }
 
@@ -174,11 +174,11 @@ section {
     border-radius: 16px;
     background: #17141d;
     box-shadow: -1rem 0 3rem #000;
-    padding: 1rem;
+    padding: 0.75rem;
     display: flex;
     align-items: center;
     justify-content: center;
-    min-height: 250px;
+    min-height: 200px;
 }
 
 .div.div1 {
@@ -302,10 +302,10 @@ section {
    ============================================ */
 
 .card {
-    width: 90%;
+    width: 85%;
     max-width: 100%;
     margin: 0 auto;
-    padding: 1.5rem;
+    padding: 1rem;
     border-radius: 16px;
     background: #17141d;
     box-shadow: -1rem 0 3rem #000;
@@ -325,14 +325,15 @@ section {
 }
 
 .card-header p {
-    font-size: 24px;
-    margin: 0 0 1rem;
+    font-size: 1rem;
+    margin: 0 0 0.5rem;
     color: #7a7a8c;
+    line-height: 1.4;
 }
 
 .card-header h2 {
-    font-size: 40px;
-    margin: 0.25rem 0 auto;
+    font-size: 1.5rem;
+    margin: 0.25rem 0 0.5rem;
     text-decoration: none;
     color: #d4d4d4;
     border: 0;
@@ -520,12 +521,12 @@ card.content {
 }
 
 .logo-icon img {
-    width: 50%;
-    height: 100%;
+    width: 80px;
+    height: 80px;
     border-radius: 100%;
     filter: grayscale(75%);
-    display: -webkit-flex;
-    margin: 30px 2px 2px;
+    display: block;
+    margin: 0.5rem auto;
 }
 
 .author-name {


### PR DESCRIPTION
FIXES:
1. Increased grid spacing to prevent collisions
   - grid-row-gap: 2% → 5% (more vertical space between rows)
   - grid-column-gap: 2.5% → 3% (more horizontal space)
   - grid-template-rows: 0.1fr → 0.5fr (taller rows)
   - padding-top: 1% → 3%, padding-bottom: 3% → 5%

2. Reduced card width for better inner/outer box gap
   - Card width: 90% → 85%
   - Card padding: 1.5rem → 1rem (more compact)

3. Optimized .div container sizing
   - Padding: 1rem → 0.75rem
   - min-height: 250px → 200px (prevents excessive height)

4. Reduced text sizes to prevent overflow
   - .card-header h2: 40px → 1.5rem
   - .card-header p: 24px → 1rem
   - Added line-height: 1.4 to paragraph
   - Reduced margins for tighter layout

5. Fixed logo image sizing
   - Changed from 50% width to fixed 80px × 80px
   - Centered with margin: 0.5rem auto
   - Changed display: -webkit-flex → block

IMPACT:
- No more box collisions between grid items
- Proper spacing between top element and grid
- Cards fit nicely inside outer divs with visible gap
- Text no longer overflows from boxes
- Better visual hierarchy with responsive spacing
- Cleaner, more organized grid layout

All CSS fixes - no HTML changes.