### PR TITLE
Fix homepage grid - Reduce card size and increase row spacing

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -164,7 +164,7 @@ section {
     grid-column-gap: 3%;
     padding-bottom: 5%;
     padding-top: 3%;
-    grid-row-gap: 5%;
+    grid-row-gap: 8%;
     grid-auto-flow: column;
 }
 
@@ -174,11 +174,12 @@ section {
     border-radius: 16px;
     background: #17141d;
     box-shadow: -1rem 0 3rem #000;
-    padding: 0.75rem;
+    padding: 0.5rem;
     display: flex;
     align-items: center;
     justify-content: center;
-    min-height: 200px;
+    min-height: 220px;
+    height: auto;
 }
 
 .div.div1 {
@@ -302,10 +303,10 @@ section {
    ============================================ */
 
 .card {
-    width: 85%;
+    width: 75%;
     max-width: 100%;
     margin: 0 auto;
-    padding: 1rem;
+    padding: 0.75rem;
     border-radius: 16px;
     background: #17141d;
     box-shadow: -1rem 0 3rem #000;
@@ -313,6 +314,8 @@ section {
     scroll-snap-align: start;
     clear: both;
     transition: 0.5s ease;
+    max-height: 100%;
+    overflow: hidden;
 }
 
 .card:hover {
@@ -320,20 +323,20 @@ section {
 }
 
 .card-header {
-    margin: 5% 3% 3% 3%;
+    margin: 0.5rem;
     margin-bottom: auto;
 }
 
 .card-header p {
-    font-size: 1rem;
-    margin: 0 0 0.5rem;
+    font-size: 0.85rem;
+    margin: 0 0 0.25rem;
     color: #7a7a8c;
-    line-height: 1.4;
+    line-height: 1.3;
 }
 
 .card-header h2 {
-    font-size: 1.5rem;
-    margin: 0.25rem 0 0.5rem;
+    font-size: 1.25rem;
+    margin: 0 0 0.25rem;
     text-decoration: none;
     color: #d4d4d4;
     border: 0;
@@ -521,12 +524,12 @@ card.content {
 }
 
 .logo-icon img {
-    width: 80px;
-    height: 80px;
+    width: 60px;
+    height: 60px;
     border-radius: 100%;
     filter: grayscale(75%);
     display: block;
-    margin: 0.5rem auto;
+    margin: 0.25rem auto;
 }
 
 .author-name {


### PR DESCRIPTION
FIXES:
1. Increased vertical spacing between rows
   - grid-row-gap: 5% → 8% (60% increase in vertical space)
   - Prevents cards from overflowing into rows below

2. Reduced card size to fit within parent divs
   - Card width: 85% → 75%
   - Card padding: 1rem → 0.75rem
   - Added max-height: 100% and overflow: hidden to prevent overflow

3. Optimized .div containers
   - Padding: 0.75rem → 0.5rem
   - min-height: 200px → 220px (slightly taller)
   - Added height: auto for flexibility

4. Reduced text sizes for better fit
   - .card-header h2: 1.5rem → 1.25rem
   - .card-header p: 1rem → 0.85rem
   - .card-header margin: 5% 3% 3% 3% → 0.5rem (much more compact)
   - Reduced line-height: 1.4 → 1.3
   - Reduced all margins for tighter layout

5. Reduced logo icon size
   - Logo images: 80px → 60px
   - Logo margin: 0.5rem → 0.25rem

IMPACT:
- Cards no longer overflow from parent divs
- Proper vertical spacing between rows (no collisions)
- Inner cards clearly smaller than outer divs with visible gap
- Cleaner, more compact layout
- Text fits properly without overflow
- Better visual hierarchy

All CSS fixes - no HTML changes.