### PR TITLE
Fix overflow issues and update copyright year

### DIFF
--- a/index.html
+++ b/index.html
@@ -214,7 +214,7 @@
 </section>
 <footer class="footer">
 
-    <h2>Jeremy Laratro 2022&copy</h2>
+    <h2>Jeremy Laratro 2025&copy;</h2>
 </footer>
 
 

--- a/styles.css
+++ b/styles.css
@@ -89,18 +89,18 @@ section {
 }
 
 .container.header {
-    width: 100%;
+    width: 95%;
     max-width: 100%;
     position: relative;
-    padding: 1rem;
-    margin: 0.5rem auto;
+    padding: 0.5rem;
+    margin: 0.25rem auto;
     border-radius: 1rem;
     box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
 }
 
 .container.header h1 {
-    font-size: 1.5rem;
-    margin: 0;
+    font-size: 1.25rem;
+    margin: 0.25rem 0;
     text-decoration: none;
     color: #d4d4d4;
     border: 0;
@@ -140,9 +140,14 @@ section {
 .grid-item {
     position: relative;
     text-align: center;
-    padding: 3%;
+    padding: 1rem;
     width: 100%;
     max-width: 100%;
+}
+
+.grid-item h1 {
+    font-size: 2rem;
+    margin: 0.25rem 0;
 }
 
 .spacer {
@@ -188,6 +193,8 @@ section {
 
 .div.div2 {
     grid-area: 1 / 2 / 2 / 5;
+    min-height: 180px;
+    padding: 1rem;
 }
 
 .div3 {
@@ -200,6 +207,20 @@ section {
 
 .div.div5 {
     grid-area: 2 / 4 / 3 / 5;
+}
+
+/* Specific fix for hardware card overflow */
+.div.div5 .card {
+    width: 70%;
+    padding: 0.5rem;
+}
+
+.div.div5 .card-header h2 {
+    font-size: 1.1rem;
+}
+
+.div.div5 .card-header p {
+    font-size: 0.75rem;
 }
 
 .div.div6 {


### PR DESCRIPTION
FIXES:
1. Fixed div.div2 (welcome box) overflow
   - Increased min-height: 180px
   - Added padding: 1rem for better containment
   - Prevents container.header from overflowing bottom

2. Reduced container.header size
   - Width: 100% → 95%
   - Padding: 1rem → 0.5rem
   - Margin: 0.5rem → 0.25rem
   - h1 font-size: 1.5rem → 1.25rem
   - Added margin: 0.25rem 0 to h1 for spacing

3. Fixed welcome text overflow at top
   - .grid-item padding: 3% → 1rem (more controlled)
   - Added .grid-item h1 style: font-size: 2rem, margin: 0.25rem 0
   - Prevents h1 "Welcome!" from overflowing top of div

4. Fixed hardware card (div.div5) overflow
   - Specific styling for .div.div5 .card
   - Card width: 75% → 70%
   - Card padding: 0.75rem → 0.5rem
   - h2 font-size: 1.25rem → 1.1rem
   - p font-size: 0.85rem → 0.75rem
   - Prevents hardware card from overflowing parent div

5. Updated copyright year
   - Changed footer from "2022" to "2025"
   - Fixed &copy formatting (added semicolon)

IMPACT:
- Welcome box properly contains all content (top and bottom)
- Hardware card no longer overflows
- All text stays within bounds of parent divs
- Cleaner, more professional layout
- Copyright year is current

All fixes maintain responsive design and existing functionality.