### PR TITLE
Fix navigation pane layout

### DIFF
--- a/navigation.js
+++ b/navigation.js
@@ -12,10 +12,6 @@
         <div class="container main text-center padding-0">
             <div class="parent hard top height-5-percent">
                 <div class="div1 hard top">
-                    <div class="card-header"></div>
-                </div>
-                <div class="div2 hard top"></div>
-                <div class="div3 hard top">
                     <div class="container top text-center">
                         <div class="rfbackground margin-0 display-fit-content">
                             <div class="card-header">
@@ -26,7 +22,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="div4 hard top">
+                <div class="div2 hard top">
                     <div class="container top text-center">
                         <div class="rfbackground margin-0 display-fit-content">
                             <div class="card-header">
@@ -37,7 +33,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="div5 hard top">
+                <div class="div3 hard top">
                     <div class="container top text-center">
                         <div class="rfbackground margin-0 display-fit-content">
                             <div class="card-header">
@@ -48,7 +44,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="div6 hard top">
+                <div class="div4 hard top">
                     <div class="container top text-center">
                         <div class="rfbackground margin-0 display-fit-content">
                             <div class="card-header">
@@ -59,7 +55,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="div7 hard top">
+                <div class="div5 hard top">
                     <div class="container top text-center">
                         <div class="rfbackground margin-0 display-fit-content">
                             <div class="card-header">
@@ -70,7 +66,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="div8 hard top">
+                <div class="div6 hard top">
                     <div class="container top text-center">
                         <div class="rfbackground margin-0 display-fit-content">
                             <div class="card-header">
@@ -81,7 +77,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="div1 hard top">
+                <div class="div7 hard top">
                     <div class="container top text-center">
                         <div class="rfbackground margin-0 display-fit-content">
                             <div class="card-header">

--- a/styles.css
+++ b/styles.css
@@ -239,42 +239,39 @@ section {
 /* Navigation Grid */
 .parent.hard.top {
     display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    grid-column-gap: 0;
+    grid-template-columns: repeat(7, 1fr);
+    grid-column-gap: 0.5rem;
     grid-row-gap: 0;
     height: 5%;
+    align-items: center;
 }
 
 .div1.hard.top {
-    grid-area: 1 / 1 / 5 / 2;
+    grid-column: 1;
 }
 
 .div2.hard.top {
-    grid-area: 2 / 1 / 2 / 2;
+    grid-column: 2;
 }
 
 .div3.hard.top {
-    grid-area: 1 / 2 / 2 / 3;
+    grid-column: 3;
 }
 
 .div4.hard.top {
-    grid-area: 2 / 2 / 3 / 3;
+    grid-column: 4;
 }
 
 .div5.hard.top {
-    grid-area: 3 / 2 / 4 / 3;
+    grid-column: 5;
 }
 
 .div6.hard.top {
-    grid-area: 4 / 2 / 5 / 3;
+    grid-column: 6;
 }
 
 .div7.hard.top {
-    grid-area: 3 / 1 / 3 / 1;
-}
-
-.div8.hard.top {
-    grid-area: 4 / 1 / 4 / 1;
+    grid-column: 7;
 }
 
 /* Hardware Grid */
@@ -974,8 +971,7 @@ body {
     .div4.hard.top,
     .div5.hard.top,
     .div6.hard.top,
-    .div7.hard.top,
-    .div8.hard.top {
+    .div7.hard.top {
         grid-area: auto;
         width: 100%;
     }
@@ -1105,11 +1101,12 @@ body {
         width: 80%;
     }
 
-    /* Navigation - 2 columns on tablet */
+    /* Navigation - 4 columns on tablet */
     .parent.hard.top {
         display: grid;
-        grid-template-columns: repeat(2, 1fr);
+        grid-template-columns: repeat(4, 1fr);
         gap: 0.5rem;
+        height: auto;
     }
 
     /* Homepage grid - 2 columns on tablet */


### PR DESCRIPTION
- Removed empty divs from navigation structure
- Updated navigation to use 7 evenly-distributed items (div1-div7)
- Changed grid layout from 2-column to 7-column on desktop
- Updated tablet view to use 4-column grid
- Updated mobile view to remove reference to div8
- All navigation links now properly spaced and distributed