### PR TITLE
Simplify navigation grid layout to proper 3x2

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -240,37 +240,12 @@ section {
 .parent.hard.top {
     display: grid;
     grid-template-columns: repeat(3, 1fr);
-    grid-template-rows: repeat(2, 1fr);
-    grid-column-gap: 1rem;
-    grid-row-gap: 0.5rem;
+    grid-auto-flow: row;
+    gap: 1rem;
     height: auto;
-    min-height: 80px;
+    min-height: 100px;
     align-items: center;
-    padding: 0.5rem 0;
-}
-
-.div1.hard.top {
-    grid-area: 1 / 1 / 2 / 2;
-}
-
-.div2.hard.top {
-    grid-area: 1 / 2 / 2 / 3;
-}
-
-.div3.hard.top {
-    grid-area: 1 / 3 / 2 / 4;
-}
-
-.div4.hard.top {
-    grid-area: 2 / 1 / 3 / 2;
-}
-
-.div5.hard.top {
-    grid-area: 2 / 2 / 3 / 3;
-}
-
-.div6.hard.top {
-    grid-area: 2 / 3 / 3 / 4;
+    padding: 1rem;
 }
 
 /* Hardware Grid */
@@ -955,26 +930,15 @@ body {
         font-size: 1rem;
     }
 
-    /* Navigation - Stack vertically on mobile */
-    /* Navigation - 2 columns x 3 rows on mobile */
+    /* Navigation - 2 columns on mobile */
     .parent.hard.top {
         display: grid;
         grid-template-columns: repeat(2, 1fr);
-        grid-template-rows: repeat(3, 1fr);
+        grid-auto-flow: row;
+        gap: 0.75rem;
         height: auto;
         width: 100%;
-        gap: 0.5rem;
-        min-height: auto;
-    }
-
-    .div1.hard.top,
-    .div2.hard.top,
-    .div3.hard.top,
-    .div4.hard.top,
-    .div5.hard.top,
-    .div6.hard.top {
-        grid-area: auto;
-        width: 100%;
+        padding: 0.75rem;
     }
 
     .testbutton {
@@ -1102,14 +1066,14 @@ body {
         width: 80%;
     }
 
-    /* Navigation - 3 columns x 2 rows on tablet */
+    /* Navigation - 3 columns on tablet */
     .parent.hard.top {
         display: grid;
         grid-template-columns: repeat(3, 1fr);
-        grid-template-rows: repeat(2, 1fr);
-        gap: 0.5rem;
+        grid-auto-flow: row;
+        gap: 0.75rem;
         height: auto;
-        min-height: 80px;
+        padding: 0.75rem;
     }
 
     /* Homepage grid - 2 columns on tablet */


### PR DESCRIPTION
Fixes:
- Removed explicit grid-area assignments
- Use grid-auto-flow for natural 3x2 layout
- Desktop: 3 columns (auto-flows to 2 rows with 6 items)
- Tablet: 3 columns (auto-flows to 2 rows)
- Mobile: 2 columns (auto-flows to 3 rows)

Navigation items now flow naturally into the grid: | button | button | button |
| button | button | button |