### PR TITLE
Fix current page detection and remove blank space

### DIFF
--- a/navigation.js
+++ b/navigation.js
@@ -7,8 +7,18 @@
 (function() {
     'use strict';
 
-    // Get current page filename
-    const currentPage = window.location.pathname.split('/').pop() || 'index.html';
+    // Get current page filename and normalize it
+    let currentPage = window.location.pathname.split('/').pop() || 'index.html';
+
+    // Ensure .html extension for comparison
+    if (!currentPage.includes('.')) {
+        currentPage = currentPage + '.html';
+    }
+
+    // Handle empty path (root) as index.html
+    if (currentPage === '' || currentPage === '/') {
+        currentPage = 'index.html';
+    }
 
     // Define all navigation links
     const navLinks = [
@@ -22,7 +32,9 @@
     ];
 
     // Filter out current page
-    const filteredLinks = navLinks.filter(link => link.href !== currentPage);
+    const filteredLinks = navLinks.filter(link => {
+        return link.href !== currentPage;
+    });
 
     // Build navigation HTML
     let navItemsHTML = '';
@@ -43,7 +55,7 @@
 
     const navigationHTML = `
         <div class="container main text-center padding-0">
-            <div class="parent hard top height-5-percent">${navItemsHTML}
+            <div class="parent hard top">${navItemsHTML}
             </div>
         </div>
     `;

--- a/styles.css
+++ b/styles.css
@@ -242,9 +242,7 @@ section {
     grid-template-columns: repeat(3, 1fr);
     grid-auto-flow: row;
     gap: 1rem;
-    height: auto;
-    min-height: 100px;
-    align-items: center;
+    align-items: stretch;
     padding: 1rem;
 }
 


### PR DESCRIPTION
- Improved current page detection to handle URLs with/without .html
- Removed height-5-percent class from navigation container
- Removed min-height from navigation grid CSS
- Changed align-items from center to stretch for better fit
- Navigation now properly hides current page link
- No more blank space below navigation buttons