### PR TITLE
Improve navigation styling and fix hardware page layout

### DIFF
--- a/hardware.html
+++ b/hardware.html
@@ -107,50 +107,25 @@
     </div>
 
 
-    <div class="container hardware" style="">
-        <div class="parent hard cnc">
-            <div class="div1 hc">
-                <div class="container header" style="position: center;">
-                    <h3> Builds: Mini-CNC Machine with GRBL Open Source Controller</h3>
-                </div>
-            </div>
-
-            <div class="parent hard cnc" style="place-items: center; column-count: 2">
-                <div class="div1 hc">
-
-                </div>
-
-                <!--    <div class="div2 hc"style="margin-right:3%">-->
-                <img src="img/20210807_213240.jpg" alt="u-logo"
-                     style="width:75%;border-radius: 2%;grid-area: 1/ 3 / 2 / 3;">
-                <!--    </div>-->
-                <!--    <div class="div3 hc">-->
-                <img src="img/20210807_232255.jpg" alt="u-logo"
-                     style="width:75%;border-radius: 2%;grid-area: 2 / 3 / 3 / 4;">
-                <!--    </div>-->
-                <!--        <div class="div4 hc" style="margin-left:3%">-->
-                <div class="div5 hc">
-                    <!--        <div class="container hardware" style="">-->
-                    <p>Pictured above is the mini-CNC I built using aluminum extrusion, stepper motors, a 10k rpm
-                        spindle motor, and an open-source GRBL control board.
-                        I was able to build the CNC for less than $200 total. My software workflow for milling PCBs
-                        was KiCAD (design the PCB, plot the GRBR files) --&gt; FlatCAM (turn the
-                        GRBRs into a CAM file with the traces inverted --&gt; bCNC (an open source CNC control
-                        software written in python. I tried various different software but this was my
-                        favorite as it had various options including an autolevel function (create heightmaps for
-                        even milling), simple GCode editing, and extensive customizability overall
-                        for various purposes. </p>
-                    <!--        </div>-->
-                </div>
-                <img src="img/20210814_115028.jpg" alt="u-logo"
-                     style="width:70%;;border-radius: 2%;grid-area: 3 / 1 / 1 / 1;">
-                <!--    </div>-->
-                <!--    <div class="div6 hc">-->
-                <img src="img/20210809_132539.jpg" alt="u-logo"
-                     style="width:75%;border-radius: 2%;grid-area: 3 / 2 / 4 / 3;">
-    
-            </div>
+    <div class="container hardware" style="text-align: center;">
+        <div class="container header" style="margin: auto;">
+            <h3> Builds: Mini-CNC Machine with GRBL Open Source Controller</h3>
         </div>
+        <div class="basic-grid" style="margin: 1rem 0;">
+            <img src="img/20210807_213240.jpg" alt="CNC Machine Build" style="width:100%; border-radius: 8px;">
+            <img src="img/20210807_232255.jpg" alt="CNC Machine Detail" style="width:100%; border-radius: 8px;">
+            <img src="img/20210814_115028.jpg" alt="CNC Milling" style="width:100%; border-radius: 8px;">
+            <img src="img/20210809_132539.jpg" alt="CNC Result" style="width:100%; border-radius: 8px;">
+        </div>
+        <p>Pictured above is the mini-CNC I built using aluminum extrusion, stepper motors, a 10k rpm
+            spindle motor, and an open-source GRBL control board.
+            I was able to build the CNC for less than $200 total. My software workflow for milling PCBs
+            was KiCAD (design the PCB, plot the GRBR files) --&gt; FlatCAM (turn the
+            GRBRs into a CAM file with the traces inverted --&gt; bCNC (an open source CNC control
+            software written in python. I tried various different software but this was my
+            favorite as it had various options including an autolevel function (create heightmaps for
+            even milling), simple GCode editing, and extensive customizability overall
+            for various purposes.</p>
     </div>
     <div class="container hardware">
         <div class="parent gps" style="display: grid;grid-template-columns: 1fr 1fr;place-items: center;">

--- a/styles.css
+++ b/styles.css
@@ -560,21 +560,25 @@ card.content {
    10. NAVIGATION
    ============================================ */
 
-/* Modern Navigation Bar */
+/* Modern Navigation Bar - Floating Style */
 .site-nav {
     background: linear-gradient(135deg, #17141d 0%, #1e1a26 100%);
-    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+    border: 1px solid rgba(255, 255, 255, 0.15);
     padding: 0;
     position: sticky;
-    top: 0;
+    top: 1rem;
     z-index: 1000;
-    box-shadow: 0 2px 20px rgba(0, 0, 0, 0.3);
+    box-shadow: 0 4px 30px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(255, 255, 255, 0.05);
+    border-radius: 16px;
+    margin: 1rem auto;
+    max-width: 95%;
+    width: fit-content;
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
 }
 
 .site-nav-container {
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 0 1rem;
+    padding: 0 0.5rem;
 }
 
 .site-nav-list {
@@ -985,7 +989,10 @@ body {
     /* Mobile Navigation */
     .site-nav {
         position: sticky;
-        top: 0;
+        top: 0.5rem;
+        margin: 0.5rem;
+        max-width: calc(100% - 1rem);
+        border-radius: 12px;
     }
 
     .site-nav-container {
@@ -1001,6 +1008,7 @@ body {
         width: 100%;
         padding: 0.75rem;
         border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+        border-radius: 12px 12px 0 0;
     }
 
     .nav-toggle-label {


### PR DESCRIPTION
- Make navigation bar float with rounded edges (16px border-radius)
- Add backdrop blur effect for modern glass-like appearance
- Center navigation with width: fit-content
- Fix CNC section on hardware page - simplify grid layout
- Use basic-grid for consistent image display